### PR TITLE
Added option to generate all XYZ available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This is currently availabe for the following X/Y/Z options:
 - Cond. Image Mask Weight
 - VAE
 
+Any other options and extra parameters can be enabled with the `Add Extra Generation Parameters` option through the UI's Settings pane. (:warning:_formatting can get wonky_)
+
 ## Installation
 
 The extension can be installed directly from within the **Extensions** tab within the Webui.

--- a/scripts/sd_grid_add_image_number.py
+++ b/scripts/sd_grid_add_image_number.py
@@ -9,7 +9,7 @@ import os
 
 xyz_infos = {}
 default_font_size = 24
-min_font_size = 14
+min_font_size = 9 # reduced the minimum font size to try and avoid overlapping textboxes
 
 xyz_options = {
     "Nothing": None,
@@ -41,26 +41,43 @@ xyz_options = {
 def on_ui_settings():
     opts.add_option("sd_grid_add_image_number", OptionInfo(True, "Add the image's number to its picture in the grid (when 'Add number to filename' is on)", section=("saving-images", "Saving images/grids")))
     opts.add_option("sd_grid_add_xyz_info", OptionInfo(False, "Add X/Y/Z script info to its picture in the grid", section=("saving-images", "Saving images/grids")))
+    opts.add_option("sd_grid_add_extra_generation_parameters", OptionInfo(False, "Add extra generation parameters to its picture in the grid", section=("saving-images", "Saving images/grids")))
 script_callbacks.on_ui_settings(on_ui_settings)
+
+# OneLiner to retrieve the value of a key in a dict, case insensitive
+def get_case_insensitive_key_value(dict, key):
+    return next((value for dict_key, value in dict.items() if dict_key.lower() == key.lower()), None)
 
 def getaxis_value(p, img_filename, getaxis):
     global xyz_infos
     axis_value = None
+    axis_option = None
     if hasattr(state, getaxis):
-        axis_option = xyz_options[getattr(getattr(state, getaxis), "axis").label]
-        if axis_option == "#1":
-            axis_value = os.path.basename(p.sd_model.sd_model_checkpoint)
-        elif axis_option == "#2":
-            axis_value = opts.CLIP_stop_at_last_layers
-        elif axis_option == "#3":
-            axis_value = os.path.basename(modules.sd_vae.loaded_vae_file)
-        elif axis_option is not None:
-            axis_value = getattr(p, axis_option)
+        api_option = getattr(getattr(state, getaxis), "axis").label
+        # Try to get the value from default p attributes
+        try:
+            axis_option = xyz_options[api_option]
+            if axis_option == "#1":
+                axis_value = os.path.basename(p.sd_model.sd_model_checkpoint)
+            elif axis_option == "#2":
+                axis_value = opts.CLIP_stop_at_last_layers
+            elif axis_option == "#3":
+                axis_value = os.path.basename(modules.sd_vae.loaded_vae_file)
+            elif axis_option is not None:
+                axis_value = getattr(p, axis_option)
+        # If the option is not in the dict, try to get it from the p.extra_generation_params
+        except KeyError:
+            if opts.sd_grid_add_extra_generation_parameters:
+                try:
+                    axis_value = get_case_insensitive_key_value(p.extra_generation_params, api_option)
+                # Since it wasn't found anywhere, set value to None and continue as an unkwnon option
+                except AttributeError:
+                    axis_value = None
     xyz_infos[img_filename][getaxis] = axis_value
 
 def handle_image_saved(params : script_callbacks.ImageSaveParams):
     global xyz_infos
-    if opts.sd_grid_add_xyz_info:
+    if opts.sd_grid_add_xyz_info or opts.sd_grid_add_extra_generation_parameters:
         if hasattr(params.image, "already_saved_as"):
             img_filename = params.image.already_saved_as
             xyz_infos[img_filename] = {}
@@ -161,7 +178,7 @@ def bottom_right(img_text, img_num_distance, img_num_height, img_num_width, img_
 
 # Insert individual image infos, in corners, in front of a box
 def handle_image_grid(params : script_callbacks.ImageGridLoopParams):
-    if opts.sd_grid_add_image_number or opts.sd_grid_add_xyz_info:
+    if opts.sd_grid_add_image_number or opts.sd_grid_add_xyz_info or opts.sd_grid_add_extra_generation_parameters:
         for i, img in enumerate(params.imgs):
             if hasattr(img, "already_saved_as"):
                 img_filename = img.already_saved_as
@@ -195,3 +212,4 @@ def handle_image_grid(params : script_callbacks.ImageGridLoopParams):
                         pass
                     params.imgs[i] = img
 script_callbacks.on_image_grid(handle_image_grid)
+


### PR DESCRIPTION
Added a fix so that the `getaxis_value` method would stop throwing exceptions on items not found on `xyz_options`.
Also added a new option (`sd_grid_add_extra_generation_parameters`, default: `False`) so that the user can chose to add a __raw__ vision from info pulling from `params.p.extra_generation_params`.

This modification allows to add options such as _additional networks_, _UniPC Order_ (available on vladmandic's UI fork) or basically anything that the API exposes through `extra_generation_params` into the generated images.